### PR TITLE
fix: Extract text content from assistant messages in SDK layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-ai-provider",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Vercel AI Provider for Claude Code CLI integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -322,53 +322,8 @@ export class ClaudeCodeLanguageModel implements LanguageModelV1 {
               // Handle assistant messages (text deltas)
               if (data.type === 'assistant') {
                 // Extract text content from the assistant message
-                let extractedText = ''
-
-                try {
-                  const messageObj = data.message
-
-                  // Handle Anthropic message format with content array
-                  if (
-                    messageObj &&
-                    typeof messageObj === 'object' &&
-                    messageObj.content &&
-                    Array.isArray(messageObj.content)
-                  ) {
-                    // Extract all text content from the array
-                    const textContents = messageObj.content
-                      .filter(
-                        (c: unknown): c is { type: string; text: string } =>
-                          typeof c === 'object' &&
-                          c !== null &&
-                          'type' in c &&
-                          'text' in c &&
-                          c.type === 'text' &&
-                          typeof c.text === 'string',
-                      )
-                      .map((c: { type: string; text: string }) => c.text)
-                      .filter(Boolean)
-
-                    extractedText = textContents.join('')
-                  }
-                  // Handle string message
-                  else if (typeof messageObj === 'string') {
-                    extractedText = messageObj
-                  }
-                  // Handle direct text property
-                  else if (
-                    messageObj &&
-                    typeof messageObj === 'object' &&
-                    'text' in messageObj &&
-                    typeof messageObj.text === 'string'
-                  ) {
-                    extractedText = messageObj.text
-                  }
-                } catch (e) {
-                  // Fallback to string representation
-                  if (typeof data.message === 'string') {
-                    extractedText = data.message
-                  }
-                }
+                // After SDK conversion, data.message is always a string
+                const extractedText = data.message
 
                 // Send text delta if we have new content
                 if (extractedText && extractedText !== currentText) {

--- a/src/claude-code-sdk.ts
+++ b/src/claude-code-sdk.ts
@@ -301,12 +301,54 @@ export class ClaudeCodeSDK {
           // Add other system properties as needed
         } as ClaudeCodeSDKMessage
 
-      case 'assistant':
+      case 'assistant': {
+        // Extract text content from the message object
+        let textContent = ''
+        const msg = message.message
+
+        // Handle Anthropic message format with content array
+        if (
+          msg &&
+          typeof msg === 'object' &&
+          'content' in msg &&
+          Array.isArray(msg.content)
+        ) {
+          // Extract all text content from the array
+          const textContents = msg.content
+            .filter(
+              (c: unknown): c is { type: string; text: string } =>
+                typeof c === 'object' &&
+                c !== null &&
+                'type' in c &&
+                'text' in c &&
+                c.type === 'text' &&
+                typeof c.text === 'string',
+            )
+            .map((c: { type: string; text: string }) => c.text)
+            .filter(Boolean)
+
+          textContent = textContents.join('')
+        }
+        // Handle string message
+        else if (typeof msg === 'string') {
+          textContent = msg
+        }
+        // Handle direct text property
+        else if (
+          msg &&
+          typeof msg === 'object' &&
+          'text' in msg &&
+          typeof msg.text === 'string'
+        ) {
+          textContent = msg.text
+        }
+
         return {
           type: 'assistant',
-          message: message.message,
+          message: textContent,
           session_id: message.session_id,
         } as ClaudeCodeSDKMessage
+      }
 
       case 'user':
         return {

--- a/src/claude-code-types.ts
+++ b/src/claude-code-types.ts
@@ -5,7 +5,6 @@
 
 // Anthropic SDK types - using generic Record for now
 // In a real implementation, you would import the actual types from the SDK
-type Message = Record<string, unknown>
 type MessageParam = Record<string, unknown>
 
 /**
@@ -15,7 +14,7 @@ export type ClaudeCodeSDKMessage =
   // Assistant message
   | {
       type: 'assistant'
-      message: Message
+      message: string
       session_id: string
     }
   // User message

--- a/tests/integration/streaming-format.test.ts
+++ b/tests/integration/streaming-format.test.ts
@@ -34,12 +34,12 @@ describe('Streaming Format Integration Tests', () => {
     expect(fullText).toContain('streaming')
     
     // No chunk should contain object-like structures
-    chunks.forEach(chunk => {
+    for (const chunk of chunks) {
       expect(chunk).not.toContain('[object Object]')
       expect(chunk).not.toContain('"type":')
       expect(chunk).not.toContain('"text":')
       expect(chunk).not.toContain('"content":')
-    })
+    }
   }, 60000)
 
   it('should handle multi-line streaming responses as plain text', async () => {

--- a/tests/integration/streaming-format.test.ts
+++ b/tests/integration/streaming-format.test.ts
@@ -1,0 +1,121 @@
+import { streamText } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { createClaudeCode } from '../../src/index.js'
+
+const claudeCode = createClaudeCode({
+  allowedTools: ['Read', 'Write', 'Bash'],
+})
+
+describe('Streaming Format Integration Tests', () => {
+  it('should stream plain text chunks, not objects', async () => {
+    const chunks: string[] = []
+    const chunkTypes: string[] = []
+    
+    const result = streamText({
+      model: claudeCode('sonnet'),
+      prompt: 'Say "Hello, streaming!" and nothing else.',
+    })
+
+    for await (const chunk of result.textStream) {
+      chunks.push(chunk)
+      chunkTypes.push(typeof chunk)
+    }
+
+    // All chunks should be strings
+    expect(chunkTypes.every(type => type === 'string')).toBe(true)
+    
+    // Should have received actual text chunks
+    expect(chunks.length).toBeGreaterThan(0)
+    
+    // Full text should be a proper string
+    const fullText = chunks.join('')
+    expect(typeof fullText).toBe('string')
+    expect(fullText).toContain('Hello')
+    expect(fullText).toContain('streaming')
+    
+    // No chunk should contain object-like structures
+    chunks.forEach(chunk => {
+      expect(chunk).not.toContain('[object Object]')
+      expect(chunk).not.toContain('"type":')
+      expect(chunk).not.toContain('"text":')
+      expect(chunk).not.toContain('"content":')
+    })
+  }, 60000)
+
+  it('should handle multi-line streaming responses as plain text', async () => {
+    const chunks: string[] = []
+    
+    const result = streamText({
+      model: claudeCode('sonnet'),
+      prompt: 'Write exactly these two lines:\nLine 1: Hello\nLine 2: World',
+    })
+
+    for await (const chunk of result.textStream) {
+      chunks.push(chunk)
+      // Verify each chunk is a string
+      expect(typeof chunk).toBe('string')
+    }
+
+    const fullText = chunks.join('')
+    expect(fullText).toContain('Hello')
+    expect(fullText).toContain('World')
+    
+    // Ensure no JSON structures leaked through
+    expect(fullText).not.toMatch(/\{"type":/i)
+    expect(fullText).not.toMatch(/\{"content":/i)
+  }, 60000)
+
+  it('should stream text incrementally without object wrappers', async () => {
+    let previousLength = 0
+    const incrementalText: string[] = []
+    
+    const result = streamText({
+      model: claudeCode('sonnet'),
+      prompt: 'Count from 1 to 3 like this: "1, 2, 3"',
+    })
+
+    for await (const chunk of result.textStream) {
+      // Each chunk should be a plain string
+      expect(typeof chunk).toBe('string')
+      
+      // Track incremental building of text
+      incrementalText.push(chunk)
+      const currentText = incrementalText.join('')
+      
+      // Text should be building incrementally
+      expect(currentText.length).toBeGreaterThanOrEqual(previousLength)
+      previousLength = currentText.length
+    }
+
+    const finalText = incrementalText.join('')
+    expect(finalText).toMatch(/1.*2.*3/s)
+  }, 60000)
+
+  it('should not expose internal message structure in streaming', async () => {
+    const result = streamText({
+      model: claudeCode('sonnet'),
+      prompt: 'Say "No objects here!" exactly.',
+    })
+
+    const chunks: string[] = []
+    for await (const chunk of result.textStream) {
+      chunks.push(chunk)
+    }
+
+    const fullText = chunks.join('')
+    
+    // Should contain the expected text
+    expect(fullText).toContain('No objects here!')
+    
+    // Should NOT contain any signs of the internal message structure
+    expect(fullText).not.toContain('"role":"assistant"')
+    expect(fullText).not.toContain('"content":[')
+    expect(fullText).not.toContain('"type":"text"')
+    expect(fullText).not.toContain('"text":')
+    expect(fullText).not.toContain('"message":')
+    expect(fullText).not.toContain('[object Object]')
+    
+    // Should not contain any JSON-like structures
+    expect(fullText).not.toMatch(/\{.*"type".*:.*"text".*\}/s)
+  }, 60000)
+})

--- a/tests/integration/streaming-format.test.ts
+++ b/tests/integration/streaming-format.test.ts
@@ -10,7 +10,7 @@ describe('Streaming Format Integration Tests', () => {
   it('should stream plain text chunks, not objects', async () => {
     const chunks: string[] = []
     const chunkTypes: string[] = []
-    
+
     const result = streamText({
       model: claudeCode('sonnet'),
       prompt: 'Say "Hello, streaming!" and nothing else.',
@@ -22,17 +22,17 @@ describe('Streaming Format Integration Tests', () => {
     }
 
     // All chunks should be strings
-    expect(chunkTypes.every(type => type === 'string')).toBe(true)
-    
+    expect(chunkTypes.every((type) => type === 'string')).toBe(true)
+
     // Should have received actual text chunks
     expect(chunks.length).toBeGreaterThan(0)
-    
+
     // Full text should be a proper string
     const fullText = chunks.join('')
     expect(typeof fullText).toBe('string')
     expect(fullText).toContain('Hello')
     expect(fullText).toContain('streaming')
-    
+
     // No chunk should contain object-like structures
     for (const chunk of chunks) {
       expect(chunk).not.toContain('[object Object]')
@@ -44,7 +44,7 @@ describe('Streaming Format Integration Tests', () => {
 
   it('should handle multi-line streaming responses as plain text', async () => {
     const chunks: string[] = []
-    
+
     const result = streamText({
       model: claudeCode('sonnet'),
       prompt: 'Write exactly these two lines:\nLine 1: Hello\nLine 2: World',
@@ -59,7 +59,7 @@ describe('Streaming Format Integration Tests', () => {
     const fullText = chunks.join('')
     expect(fullText).toContain('Hello')
     expect(fullText).toContain('World')
-    
+
     // Ensure no JSON structures leaked through
     expect(fullText).not.toMatch(/\{"type":/i)
     expect(fullText).not.toMatch(/\{"content":/i)
@@ -68,7 +68,7 @@ describe('Streaming Format Integration Tests', () => {
   it('should stream text incrementally without object wrappers', async () => {
     let previousLength = 0
     const incrementalText: string[] = []
-    
+
     const result = streamText({
       model: claudeCode('sonnet'),
       prompt: 'Count from 1 to 3 like this: "1, 2, 3"',
@@ -77,11 +77,11 @@ describe('Streaming Format Integration Tests', () => {
     for await (const chunk of result.textStream) {
       // Each chunk should be a plain string
       expect(typeof chunk).toBe('string')
-      
+
       // Track incremental building of text
       incrementalText.push(chunk)
       const currentText = incrementalText.join('')
-      
+
       // Text should be building incrementally
       expect(currentText.length).toBeGreaterThanOrEqual(previousLength)
       previousLength = currentText.length
@@ -103,10 +103,10 @@ describe('Streaming Format Integration Tests', () => {
     }
 
     const fullText = chunks.join('')
-    
+
     // Should contain the expected text
     expect(fullText).toContain('No objects here!')
-    
+
     // Should NOT contain any signs of the internal message structure
     expect(fullText).not.toContain('"role":"assistant"')
     expect(fullText).not.toContain('"content":[')
@@ -114,7 +114,7 @@ describe('Streaming Format Integration Tests', () => {
     expect(fullText).not.toContain('"text":')
     expect(fullText).not.toContain('"message":')
     expect(fullText).not.toContain('[object Object]')
-    
+
     // Should not contain any JSON-like structures
     expect(fullText).not.toMatch(/\{.*"type".*:.*"text".*\}/s)
   }, 60000)


### PR DESCRIPTION
## Summary
- Fixed streaming output showing object format instead of plain text
- Moved text extraction logic from doStream to SDK conversion layer
- Updated TypeScript types to reflect string message format

## Changes
- Move text extraction logic from `doStream` to `convertSDKMessage` in SDK layer
- Update assistant message type definition from `Message` object to `string`
- Simplify streaming text handling in language model
- Remove unused `Message` type definition
- Bump version from 0.1.1 to 0.1.2

## Test plan
- [x] Build passes with no TypeScript errors
- [x] Linting passes with no issues
- [x] Formatting is consistent with project standards
- [ ] Test streaming functionality with Claude Code CLI

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved extraction and handling of assistant message text to ensure consistent and accurate display of responses.

- **Chores**
	- Updated version number to 0.1.2.

- **Tests**
	- Added integration tests verifying streaming text output is delivered as plain strings and incrementally without exposing internal message structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->